### PR TITLE
Fix handling for empty genre filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,13 @@
       let pool = movies;
       const fs = [...selectedGenres].filter(g => g !== 0);
       if (fs.length) pool = pool.filter(m => fs.every(g => m.genre_ids.includes(g)));
+      if (!pool.length) {
+        img.removeAttribute('src');
+        txt.textContent = 'No movies found for selected genres';
+        streamLink.removeAttribute('href');
+        res.style.visibility = 'visible';
+        return;
+      }
       btn.disabled = true;
       let i = 0;
       (function spin() {


### PR DESCRIPTION
## Summary
- handle case where selected genres match no movies

## Testing
- `node -e "fetch('http://localhost:8000/data/movies.json').then(r=>r.json()).then(d=>console.log('Loaded',d.length,'movies')).catch(e=>console.error(e))"`
- `curl -s http://localhost:8000/index.html | grep -n "No movies found" -n`

------
https://chatgpt.com/codex/tasks/task_e_684ded943f948333836a5dabd660f286